### PR TITLE
Build error

### DIFF
--- a/tests/unit/utils/default-transition-test.js
+++ b/tests/unit/utils/default-transition-test.js
@@ -1,4 +1,4 @@
-import defaultTransition from '../../../utils/default-transition';
+import defaultTransition from '../../../addon/utils/default-transition';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | default transition');


### PR DESCRIPTION
Trying to fix
``````````````````
not ok 14 PhantomJS 1.9 - TestLoader Failures: dummy/tests/unit/utils/default-transition-test: could not be loaded
    ---
        actual: >
            null
        message: >
            Died on test #1     at test (http://localhost:7357/assets/test-support.js:3025)
                at http://localhost:7357/assets/test-support.js:6017
                at http://localhost:7357/assets/test-loader.js:62
                at http://localhost:7357/assets/test-loader.js:51
                at http://localhost:7357/assets/test-loader.js:82
                at http://localhost:7357/assets/test-support.js:6024: Could not find module `dummy/utils/default-transition` imported from `dummy/tests/unit/utils/default-transition-test`
```````````````
