### PR TITLE
enable passing a custom modal-dialog class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ every ones needs are different. The following is a simple example of what you ca
 
 ```hbs
 {{#if showModal}}
-  {{#bootstrap-modal close=(action 'toggleShowModal') closeOnOverlayClick=true as |modal|}}
+  {{#bootstrap-modal close=(action 'toggleShowModal') closeOnOverlayClick=true dialogClass='my-dialog' as |modal|}}
     {{#modal.header}}
       <h4 class="modal-title">Test</h4>
     {{/modal.header}}
@@ -105,6 +105,7 @@ the modal styles and want to pick and choose your files.
 * `close` - Action. The action attribute for closing the modal, e.g. `close=(action 'closeModal')`. The action will have it's first argument
   set to `true` if the modal was closed by clicking the overlay.
 * `closeOnOverlayClick` - Boolean. Flag enabling triggering the close via clicking the overlay/backdrop.
+* `dialogClass` - String. Custom CSS class that will be applied to the modal-dialog in order to enable custom styling.
 
 
 ## Developing

--- a/addon/components/bootstrap-modal/template.hbs
+++ b/addon/components/bootstrap-modal/template.hbs
@@ -1,7 +1,7 @@
 {{#liquid-wormhole
   stack='bootstrap-modal' class='bootstrap-modal'}}
   <div class="modal-backdrop {{if closeOnOverlayClick 'clickable'}}" {{action 'overlayClick'}}></div>
-  <div class="modal-dialog">
+  <div class="modal-dialog {{if customClassName customClassName}}">
     <div class="modal-content">
       {{yield (hash
         header=(component 'bootstrap-modal-header' close=(action close))

--- a/addon/components/bootstrap-modal/template.hbs
+++ b/addon/components/bootstrap-modal/template.hbs
@@ -1,7 +1,7 @@
 {{#liquid-wormhole
   stack='bootstrap-modal' class='bootstrap-modal'}}
   <div class="modal-backdrop {{if closeOnOverlayClick 'clickable'}}" {{action 'overlayClick'}}></div>
-  <div class="modal-dialog {{if customClassName customClassName}}">
+  <div class="modal-dialog {{if dialogClass dialogClass}}">
     <div class="modal-content">
       {{yield (hash
         header=(component 'bootstrap-modal-header' close=(action close))


### PR DESCRIPTION
Is there any chance to provide a way of passing a custom CSS class to `<div class="modal-dialog">` in order to enable custom styling?

Imagine a feature where modal dialog is required to look like a mobile phone and thus you would like to change modal's width/height for this specific modal within your app.

The application of the component could look like this:

` {{#bootstrap-modal
close=(action onClose)
closeOnOverlayClick=true
customClassName='preview'}}
...
{{/bootstrap-modal}}`